### PR TITLE
fix: downgrade @oclif/plugin-help to ^2.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1.2.2",
-    "@oclif/plugin-help": "^3.0.1",
+    "@oclif/plugin-help": "^2.2.3",
     "debug": "^4.1.1"
   },
   "repository": "adobe/aio-cli-plugin-events",


### PR DESCRIPTION
The help plugin, or one of its sub-dependencies, is breaking the tests in node-16 (since 7 days ago: see Actions tab daily tests which uses node-16). Tests pass on node-14. It's possible that the help plugin on v3+ does not work on node-16. Downgrading the plugin to v2 fixes this.

Closes #27 

## How Has This Been Tested?

1. npm test
2. linking the plugin at this branch and running `aio event` does not show the `TypeError: Help is not a constructor` error

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
