### PR TITLE
oclif readme --no-aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,35 +39,27 @@ $ aio event --help
 # Commands
 <!-- commands -->
 * [`aio event`](#aio-event)
-* [`aio event:eventmetadata`](#aio-eventeventmetadata)
-* [`aio event:eventmetadata:create PROVIDERID`](#aio-eventeventmetadatacreate-providerid)
-* [`aio event:eventmetadata:delete PROVIDERID [EVENTCODE]`](#aio-eventeventmetadatadelete-providerid-eventcode)
-* [`aio event:eventmetadata:get PROVIDERID EVENTCODE`](#aio-eventeventmetadataget-providerid-eventcode)
-* [`aio event:eventmetadata:list PROVIDERID`](#aio-eventeventmetadatalist-providerid)
-* [`aio event:eventmetadata:ls PROVIDERID`](#aio-eventeventmetadatals-providerid)
-* [`aio event:eventmetadata:update PROVIDERID EVENTCODE`](#aio-eventeventmetadataupdate-providerid-eventcode)
-* [`aio event:provider`](#aio-eventprovider)
-* [`aio event:provider:create`](#aio-eventprovidercreate)
-* [`aio event:provider:delete PROVIDERID`](#aio-eventproviderdelete-providerid)
-* [`aio event:provider:get PROVIDERID`](#aio-eventproviderget-providerid)
-* [`aio event:provider:list`](#aio-eventproviderlist)
-* [`aio event:provider:ls`](#aio-eventproviderls)
-* [`aio event:provider:update PROVIDERID`](#aio-eventproviderupdate-providerid)
-* [`aio event:reg:create BODYJSONFILE`](#aio-eventregcreate-bodyjsonfile)
-* [`aio event:reg:delete REGISTRATIONID`](#aio-eventregdelete-registrationid)
-* [`aio event:reg:get REGISTRATIONID`](#aio-eventregget-registrationid)
-* [`aio event:reg:list`](#aio-eventreglist)
-* [`aio event:reg:ls`](#aio-eventregls)
-* [`aio event:registration`](#aio-eventregistration)
-* [`aio event:registration:create BODYJSONFILE`](#aio-eventregistrationcreate-bodyjsonfile)
-* [`aio event:registration:delete REGISTRATIONID`](#aio-eventregistrationdelete-registrationid)
-* [`aio event:registration:get REGISTRATIONID`](#aio-eventregistrationget-registrationid)
-* [`aio event:registration:list`](#aio-eventregistrationlist)
-* [`aio event:registration:ls`](#aio-eventregistrationls)
+* [`aio event eventmetadata`](#aio-event-eventmetadata)
+* [`aio event eventmetadata create PROVIDERID`](#aio-event-eventmetadata-create-providerid)
+* [`aio event eventmetadata delete PROVIDERID [EVENTCODE]`](#aio-event-eventmetadata-delete-providerid-eventcode)
+* [`aio event eventmetadata get PROVIDERID EVENTCODE`](#aio-event-eventmetadata-get-providerid-eventcode)
+* [`aio event eventmetadata list PROVIDERID`](#aio-event-eventmetadata-list-providerid)
+* [`aio event eventmetadata update PROVIDERID EVENTCODE`](#aio-event-eventmetadata-update-providerid-eventcode)
+* [`aio event provider`](#aio-event-provider)
+* [`aio event provider create`](#aio-event-provider-create)
+* [`aio event provider delete PROVIDERID`](#aio-event-provider-delete-providerid)
+* [`aio event provider get PROVIDERID`](#aio-event-provider-get-providerid)
+* [`aio event provider list`](#aio-event-provider-list)
+* [`aio event provider update PROVIDERID`](#aio-event-provider-update-providerid)
+* [`aio event registration`](#aio-event-registration)
+* [`aio event registration create BODYJSONFILE`](#aio-event-registration-create-bodyjsonfile)
+* [`aio event registration delete REGISTRATIONID`](#aio-event-registration-delete-registrationid)
+* [`aio event registration get REGISTRATIONID`](#aio-event-registration-get-registrationid)
+* [`aio event registration list`](#aio-event-registration-list)
 
 ## `aio event`
 
-Manage your Adobe I/O Events
+Manage your Adobe Developer Platform Events
 
 ```
 USAGE
@@ -79,18 +71,18 @@ FLAGS
   --version      Show version
 
 DESCRIPTION
-  Manage your Adobe I/O Events
+  Manage your Adobe Developer Platform Events
 ```
 
 _See code: [src/commands/event/index.js](https://github.com/adobe/aio-cli-plugin-events/blob/v2.0.1/src/commands/event/index.js)_
 
-## `aio event:eventmetadata`
+## `aio event eventmetadata`
 
 Manage your Adobe I/O Events Providers' Event Metadata
 
 ```
 USAGE
-  $ aio event:eventmetadata [--help] [-v] [--version]
+  $ aio event eventmetadata [--help] [-v] [--version]
 
 FLAGS
   -v, --verbose  Verbose output
@@ -101,15 +93,13 @@ DESCRIPTION
   Manage your Adobe I/O Events Providers' Event Metadata
 ```
 
-_See code: [src/commands/event/eventmetadata/index.js](https://github.com/adobe/aio-cli-plugin-events/blob/v2.0.1/src/commands/event/eventmetadata/index.js)_
-
-## `aio event:eventmetadata:create PROVIDERID`
+## `aio event eventmetadata create PROVIDERID`
 
 Create an Event Metadata for a Provider
 
 ```
 USAGE
-  $ aio event:eventmetadata:create [PROVIDERID] [--help] [-v] [--version] [-j | -y]
+  $ aio event eventmetadata create [PROVIDERID] [--help] [-v] [--version] [-j | -y]
 
 ARGUMENTS
   PROVIDERID  The requested eventmetadata event code
@@ -125,15 +115,13 @@ DESCRIPTION
   Create an Event Metadata for a Provider
 ```
 
-_See code: [src/commands/event/eventmetadata/create.js](https://github.com/adobe/aio-cli-plugin-events/blob/v2.0.1/src/commands/event/eventmetadata/create.js)_
-
-## `aio event:eventmetadata:delete PROVIDERID [EVENTCODE]`
+## `aio event eventmetadata delete PROVIDERID [EVENTCODE]`
 
 Delete Event Metadata for a Provider
 
 ```
 USAGE
-  $ aio event:eventmetadata:delete [PROVIDERID] [EVENTCODE] [--help] [-v] [--version]
+  $ aio event eventmetadata delete [PROVIDERID] [EVENTCODE] [--help] [-v] [--version]
 
 ARGUMENTS
   PROVIDERID  The requested provider ID
@@ -148,15 +136,13 @@ DESCRIPTION
   Delete Event Metadata for a Provider
 ```
 
-_See code: [src/commands/event/eventmetadata/delete.js](https://github.com/adobe/aio-cli-plugin-events/blob/v2.0.1/src/commands/event/eventmetadata/delete.js)_
-
-## `aio event:eventmetadata:get PROVIDERID EVENTCODE`
+## `aio event eventmetadata get PROVIDERID EVENTCODE`
 
 Get details of an Event Code of a Provider
 
 ```
 USAGE
-  $ aio event:eventmetadata:get [PROVIDERID] [EVENTCODE] [--help] [-v] [--version] [-j | -y]
+  $ aio event eventmetadata get [PROVIDERID] [EVENTCODE] [--help] [-v] [--version] [-j | -y]
 
 ARGUMENTS
   PROVIDERID  The requested provider ID
@@ -173,15 +159,13 @@ DESCRIPTION
   Get details of an Event Code of a Provider
 ```
 
-_See code: [src/commands/event/eventmetadata/get.js](https://github.com/adobe/aio-cli-plugin-events/blob/v2.0.1/src/commands/event/eventmetadata/get.js)_
-
-## `aio event:eventmetadata:list PROVIDERID`
+## `aio event eventmetadata list PROVIDERID`
 
 List all Event Metadata for a Provider
 
 ```
 USAGE
-  $ aio event:eventmetadata:list [PROVIDERID] [--help] [-v] [--version] [-j | -y]
+  $ aio event eventmetadata list [PROVIDERID] [--help] [-v] [--version] [-j | -y]
 
 ARGUMENTS
   PROVIDERID  The requested provider ID
@@ -197,43 +181,16 @@ DESCRIPTION
   List all Event Metadata for a Provider
 
 ALIASES
-  $ aio event:eventmetadata:ls
+  $ aio event eventmetadata ls
 ```
 
-_See code: [src/commands/event/eventmetadata/list.js](https://github.com/adobe/aio-cli-plugin-events/blob/v2.0.1/src/commands/event/eventmetadata/list.js)_
-
-## `aio event:eventmetadata:ls PROVIDERID`
-
-List all Event Metadata for a Provider
-
-```
-USAGE
-  $ aio event:eventmetadata:ls [PROVIDERID] [--help] [-v] [--version] [-j | -y]
-
-ARGUMENTS
-  PROVIDERID  The requested provider ID
-
-FLAGS
-  -j, --json     Output json
-  -v, --verbose  Verbose output
-  -y, --yml      Output yml
-  --help         Show help
-  --version      Show version
-
-DESCRIPTION
-  List all Event Metadata for a Provider
-
-ALIASES
-  $ aio event:eventmetadata:ls
-```
-
-## `aio event:eventmetadata:update PROVIDERID EVENTCODE`
+## `aio event eventmetadata update PROVIDERID EVENTCODE`
 
 Update an Event Metadata for a Provider
 
 ```
 USAGE
-  $ aio event:eventmetadata:update [PROVIDERID] [EVENTCODE] [--help] [-v] [--version] [-j | -y]
+  $ aio event eventmetadata update [PROVIDERID] [EVENTCODE] [--help] [-v] [--version] [-j | -y]
 
 ARGUMENTS
   PROVIDERID  The requested provider ID
@@ -250,15 +207,13 @@ DESCRIPTION
   Update an Event Metadata for a Provider
 ```
 
-_See code: [src/commands/event/eventmetadata/update.js](https://github.com/adobe/aio-cli-plugin-events/blob/v2.0.1/src/commands/event/eventmetadata/update.js)_
-
-## `aio event:provider`
+## `aio event provider`
 
 Manage your Adobe I/O Events Providers
 
 ```
 USAGE
-  $ aio event:provider [--help] [-v] [--version]
+  $ aio event provider [--help] [-v] [--version]
 
 FLAGS
   -v, --verbose  Verbose output
@@ -269,15 +224,13 @@ DESCRIPTION
   Manage your Adobe I/O Events Providers
 ```
 
-_See code: [src/commands/event/provider/index.js](https://github.com/adobe/aio-cli-plugin-events/blob/v2.0.1/src/commands/event/provider/index.js)_
-
-## `aio event:provider:create`
+## `aio event provider create`
 
 Create a new Provider
 
 ```
 USAGE
-  $ aio event:provider:create [--help] [-v] [--version] [-j | -y]
+  $ aio event provider create [--help] [-v] [--version] [-j | -y]
 
 FLAGS
   -j, --json     Output json
@@ -290,15 +243,13 @@ DESCRIPTION
   Create a new Provider
 ```
 
-_See code: [src/commands/event/provider/create.js](https://github.com/adobe/aio-cli-plugin-events/blob/v2.0.1/src/commands/event/provider/create.js)_
-
-## `aio event:provider:delete PROVIDERID`
+## `aio event provider delete PROVIDERID`
 
 Delete Provider by id
 
 ```
 USAGE
-  $ aio event:provider:delete [PROVIDERID] [--help] [-v] [--version]
+  $ aio event provider delete [PROVIDERID] [--help] [-v] [--version]
 
 ARGUMENTS
   PROVIDERID  The requested provider ID
@@ -312,15 +263,13 @@ DESCRIPTION
   Delete Provider by id
 ```
 
-_See code: [src/commands/event/provider/delete.js](https://github.com/adobe/aio-cli-plugin-events/blob/v2.0.1/src/commands/event/provider/delete.js)_
-
-## `aio event:provider:get PROVIDERID`
+## `aio event provider get PROVIDERID`
 
 Get details of Provider by id
 
 ```
 USAGE
-  $ aio event:provider:get [PROVIDERID] [--help] [-v] [--version] [--fetchEventMetadata] [-j | -y]
+  $ aio event provider get [PROVIDERID] [--help] [-v] [--version] [--fetchEventMetadata] [-j | -y]
 
 ARGUMENTS
   PROVIDERID  The requested provider ID
@@ -337,15 +286,13 @@ DESCRIPTION
   Get details of Provider by id
 ```
 
-_See code: [src/commands/event/provider/get.js](https://github.com/adobe/aio-cli-plugin-events/blob/v2.0.1/src/commands/event/provider/get.js)_
-
-## `aio event:provider:list`
+## `aio event provider list`
 
 Get list of all Providers for the Organization
 
 ```
 USAGE
-  $ aio event:provider:list [--help] [-v] [--version] [-j | -y]
+  $ aio event provider list [--help] [-v] [--version] [-j | -y]
 
 FLAGS
   -j, --json     Output json
@@ -358,40 +305,16 @@ DESCRIPTION
   Get list of all Providers for the Organization
 
 ALIASES
-  $ aio event:provider:ls
+  $ aio event provider ls
 ```
 
-_See code: [src/commands/event/provider/list.js](https://github.com/adobe/aio-cli-plugin-events/blob/v2.0.1/src/commands/event/provider/list.js)_
-
-## `aio event:provider:ls`
-
-Get list of all Providers for the Organization
-
-```
-USAGE
-  $ aio event:provider:ls [--help] [-v] [--version] [-j | -y]
-
-FLAGS
-  -j, --json     Output json
-  -v, --verbose  Verbose output
-  -y, --yml      Output yml
-  --help         Show help
-  --version      Show version
-
-DESCRIPTION
-  Get list of all Providers for the Organization
-
-ALIASES
-  $ aio event:provider:ls
-```
-
-## `aio event:provider:update PROVIDERID`
+## `aio event provider update PROVIDERID`
 
 Update an existing Provider
 
 ```
 USAGE
-  $ aio event:provider:update [PROVIDERID] [--help] [-v] [--version] [-j | -y]
+  $ aio event provider update [PROVIDERID] [--help] [-v] [--version] [-j | -y]
 
 ARGUMENTS
   PROVIDERID  The requested provider ID
@@ -407,148 +330,13 @@ DESCRIPTION
   Update an existing Provider
 ```
 
-_See code: [src/commands/event/provider/update.js](https://github.com/adobe/aio-cli-plugin-events/blob/v2.0.1/src/commands/event/provider/update.js)_
-
-## `aio event:reg:create BODYJSONFILE`
-
-Create a new Event Registration in your Workspace
-
-```
-USAGE
-  $ aio event:reg:create [BODYJSONFILE] [--help] [-v] [--version] [-j | -y]
-
-ARGUMENTS
-  BODYJSONFILE
-      Path to a file in JSON format with the information to create a new Event Registration.
-      The JSON should follow the following format:
-      {
-      "name": "<event registration name>",
-      "description": "<event registration description>",
-      "delivery_type": "WEBHOOK|WEBHOOK_BATCH|JOURNAL",
-      "webhook_url": "<webhook URL responding to challenge>",
-      "events_of_interest": [{
-      "provider_id": "<event provider id>",
-      "event_code": "<event provider event_code metadata>"
-      }, { /* ...more events */ }]
-      }
-
-FLAGS
-  -j, --json     Output json
-  -v, --verbose  Verbose output
-  -y, --yml      Output yml
-  --help         Show help
-  --version      Show version
-
-DESCRIPTION
-  Create a new Event Registration in your Workspace
-
-ALIASES
-  $ aio event:reg:create
-```
-
-## `aio event:reg:delete REGISTRATIONID`
-
-Delete Registration
-
-```
-USAGE
-  $ aio event:reg:delete [REGISTRATIONID] [--help] [-v] [--version]
-
-ARGUMENTS
-  REGISTRATIONID  The requested registration ID
-
-FLAGS
-  -v, --verbose  Verbose output
-  --help         Show help
-  --version      Show version
-
-DESCRIPTION
-  Delete Registration
-
-ALIASES
-  $ aio event:reg:delete
-```
-
-## `aio event:reg:get REGISTRATIONID`
-
-Get an Event Registration in your Workspace
-
-```
-USAGE
-  $ aio event:reg:get [REGISTRATIONID] [--help] [-v] [--version] [-j | -y]
-
-ARGUMENTS
-  REGISTRATIONID  The requested registration ID
-
-FLAGS
-  -j, --json     Output json
-  -v, --verbose  Verbose output
-  -y, --yml      Output yml
-  --help         Show help
-  --version      Show version
-
-DESCRIPTION
-  Get an Event Registration in your Workspace
-
-ALIASES
-  $ aio event:reg:get
-```
-
-## `aio event:reg:list`
-
-List your Event Registrations in your Workspace
-
-```
-USAGE
-  $ aio event:reg:list [--help] [-v] [--version] [-j | -y]
-
-FLAGS
-  -j, --json     Output json
-  -v, --verbose  Verbose output
-  -y, --yml      Output yml
-  --help         Show help
-  --version      Show version
-
-DESCRIPTION
-  List your Event Registrations in your Workspace
-
-ALIASES
-  $ aio event:registration:ls
-  $ aio event:reg:list
-  $ aio event:reg:ls
-```
-
-## `aio event:reg:ls`
-
-List your Event Registrations in your Workspace
-
-```
-USAGE
-  $ aio event:reg:ls [--help] [-v] [--version] [-j | -y]
-
-FLAGS
-  -j, --json     Output json
-  -v, --verbose  Verbose output
-  -y, --yml      Output yml
-  --help         Show help
-  --version      Show version
-
-DESCRIPTION
-  List your Event Registrations in your Workspace
-
-ALIASES
-  $ aio event:registration:ls
-  $ aio event:reg:list
-  $ aio event:reg:ls
-```
-
-## `aio event:registration`
+## `aio event registration`
 
 Manage your Adobe I/O Events Registrations
 
 ```
 USAGE
-  $ aio event:registration [--help] [-v] [--version]
+  $ aio event registration [--help] [-v] [--version]
 
 FLAGS
   -v, --verbose  Verbose output
@@ -559,15 +347,13 @@ DESCRIPTION
   Manage your Adobe I/O Events Registrations
 ```
 
-_See code: [src/commands/event/registration/index.js](https://github.com/adobe/aio-cli-plugin-events/blob/v2.0.1/src/commands/event/registration/index.js)_
-
-## `aio event:registration:create BODYJSONFILE`
+## `aio event registration create BODYJSONFILE`
 
 Create a new Event Registration in your Workspace
 
 ```
 USAGE
-  $ aio event:registration:create [BODYJSONFILE] [--help] [-v] [--version] [-j | -y]
+  $ aio event registration create [BODYJSONFILE] [--help] [-v] [--version] [-j | -y]
 
 ARGUMENTS
   BODYJSONFILE
@@ -595,18 +381,16 @@ DESCRIPTION
   Create a new Event Registration in your Workspace
 
 ALIASES
-  $ aio event:reg:create
+  $ aio event reg create
 ```
 
-_See code: [src/commands/event/registration/create.js](https://github.com/adobe/aio-cli-plugin-events/blob/v2.0.1/src/commands/event/registration/create.js)_
-
-## `aio event:registration:delete REGISTRATIONID`
+## `aio event registration delete REGISTRATIONID`
 
 Delete Registration
 
 ```
 USAGE
-  $ aio event:registration:delete [REGISTRATIONID] [--help] [-v] [--version]
+  $ aio event registration delete [REGISTRATIONID] [--help] [-v] [--version]
 
 ARGUMENTS
   REGISTRATIONID  The requested registration ID
@@ -620,18 +404,16 @@ DESCRIPTION
   Delete Registration
 
 ALIASES
-  $ aio event:reg:delete
+  $ aio event reg delete
 ```
 
-_See code: [src/commands/event/registration/delete.js](https://github.com/adobe/aio-cli-plugin-events/blob/v2.0.1/src/commands/event/registration/delete.js)_
-
-## `aio event:registration:get REGISTRATIONID`
+## `aio event registration get REGISTRATIONID`
 
 Get an Event Registration in your Workspace
 
 ```
 USAGE
-  $ aio event:registration:get [REGISTRATIONID] [--help] [-v] [--version] [-j | -y]
+  $ aio event registration get [REGISTRATIONID] [--help] [-v] [--version] [-j | -y]
 
 ARGUMENTS
   REGISTRATIONID  The requested registration ID
@@ -647,18 +429,16 @@ DESCRIPTION
   Get an Event Registration in your Workspace
 
 ALIASES
-  $ aio event:reg:get
+  $ aio event reg get
 ```
 
-_See code: [src/commands/event/registration/get.js](https://github.com/adobe/aio-cli-plugin-events/blob/v2.0.1/src/commands/event/registration/get.js)_
-
-## `aio event:registration:list`
+## `aio event registration list`
 
 List your Event Registrations in your Workspace
 
 ```
 USAGE
-  $ aio event:registration:list [--help] [-v] [--version] [-j | -y]
+  $ aio event registration list [--help] [-v] [--version] [-j | -y]
 
 FLAGS
   -j, --json     Output json
@@ -671,35 +451,9 @@ DESCRIPTION
   List your Event Registrations in your Workspace
 
 ALIASES
-  $ aio event:registration:ls
-  $ aio event:reg:list
-  $ aio event:reg:ls
-```
-
-_See code: [src/commands/event/registration/list.js](https://github.com/adobe/aio-cli-plugin-events/blob/v2.0.1/src/commands/event/registration/list.js)_
-
-## `aio event:registration:ls`
-
-List your Event Registrations in your Workspace
-
-```
-USAGE
-  $ aio event:registration:ls [--help] [-v] [--version] [-j | -y]
-
-FLAGS
-  -j, --json     Output json
-  -v, --verbose  Verbose output
-  -y, --yml      Output yml
-  --help         Show help
-  --version      Show version
-
-DESCRIPTION
-  List your Event Registrations in your Workspace
-
-ALIASES
-  $ aio event:registration:ls
-  $ aio event:reg:list
-  $ aio event:reg:ls
+  $ aio event registration ls
+  $ aio event reg list
+  $ aio event reg ls
 ```
 <!-- commandsstop -->
 

--- a/bin/run
+++ b/bin/run
@@ -11,5 +11,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-require('@oclif/command').run()
-.catch(require('@oclif/errors/handle'))
+const oclif = require('@oclif/core')
+
+oclif.run()
+  .then(require('@oclif/core/flush'))
+  .catch(require('@oclif/core/handle'))

--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
   "oclif": {
     "commands": "./src/commands",
     "bin": "aio",
-    "topicSeparator": " "
-    },
+    "topicSeparator": " ",
     "devPlugins": [
       "@oclif/plugin-help"
     ]

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jest-haste-map": "^27.5.1",
     "jest-junit": "^10.0.0",
     "jest-resolve": "^27.5.1",
-    "oclif": "^3.0.1",
+    "oclif": "^3.2.0",
     "stdout-stderr": "^0.1.13"
   },
   "engines": {
@@ -57,7 +57,7 @@
     "posttest": "eslint src test e2e",
     "test": "npm run unit-tests",
     "unit-tests": "jest --ci",
-    "prepack": "oclif manifest && oclif readme",
+    "prepack": "oclif manifest && oclif readme --no-aliases",
     "postpack": "rm -f oclif.manifest.json",
     "version": "oclif readme && git add README.md",
     "e2e": "jest --collectCoverage=false --testRegex './e2e/e2e.js'"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
   "oclif": {
     "commands": "./src/commands",
     "bin": "aio",
+    "topicSeparator": " "
+    },
     "devPlugins": [
       "@oclif/plugin-help"
     ]


### PR DESCRIPTION
The new oclif README doc generator was listing the aliases as well as commands (which just clutters up the README docs), now there is a new flag --no-aliases. 