### PR TITLE
Support for oAuth server-to-server credential

### DIFF
--- a/src/BaseCommand.js
+++ b/src/BaseCommand.js
@@ -32,7 +32,7 @@ class BaseCommand extends Command {
     // login
     await context.setCli({ 'cli.bare-output': true }, false) // set this globally
     aioLogger.debug('run login')
-    this.accessToken = await getToken(CLI) // user access token, would work with jwt too
+    this.accessToken = await getToken(CLI) // user access token, would work with JWT/OAuth Server-to-Server token too
 
     // init console sdk
     this.consoleClient = await Console.init(this.accessToken, CONSOLE_API_KEY)

--- a/src/BaseCommand.js
+++ b/src/BaseCommand.js
@@ -131,7 +131,7 @@ class BaseCommand extends Command {
                  c.integration_type === JWT_INTEGRATION_TYPE
         })
     if (!workspaceIntegration) {
-      throw new Error(`Workspace ${workspaceConfig.name} has no JWT integration`)
+      throw new Error(this.getErrorMessageForInvalidCredentials(workspaceConfig.name))
     }
     return workspaceIntegration
   }
@@ -154,6 +154,16 @@ class BaseCommand extends Command {
     // clean undefined values
     data = JSON.parse(JSON.stringify(data))
     this.log(yaml.safeDump(data, { noCompatMode: true }))
+  }
+
+  /**
+   * Returns error message for invalid credential configuration in a workspace
+   *
+   * @param {string} workspaceName - name of the workspace
+   * @returns {string} error message in case the workspace has invalid credential configuration
+   */
+  getErrorMessageForInvalidCredentials (workspaceName) {
+    return `Workspace ${workspaceName} has no oAuth Server-to-Server or JWT credential associated.`
   }
 }
 

--- a/src/BaseCommand.js
+++ b/src/BaseCommand.js
@@ -44,8 +44,8 @@ class BaseCommand extends Command {
     aioLogger.debug(`${JSON.stringify(this.conf)}`)
 
     // init the event client
-    aioLogger.debug(`initializing aio-lib-events with org=${this.conf.org.code}, apiKey(jwtClientId)=${this.conf.integration.jwtClientId} and accessToken=<hidden>`)
-    this.eventClient = await Events.init(this.conf.org.code, this.conf.integration.jwtClientId, this.accessToken)
+    aioLogger.debug(`initializing aio-lib-events with org=${this.conf.org.code}, apiKey(clientId)=${this.conf.integration.clientId} and accessToken=<hidden>`)
+    this.eventClient = await Events.init(this.conf.org.code, this.conf.integration.clientId, this.accessToken)
   }
 
   // Note: loadConfig should be shared across plugins at the aio-lib-ims level
@@ -71,7 +71,7 @@ class BaseCommand extends Command {
         org: { id: localProject.org.id, name: localProject.org.name, code: localProject.org.ims_org_id },
         project: { id: localProject.id, name: localProject.name, title: localProject.title },
         workspace: { id: localProject.workspace.id, name: localProject.workspace.name },
-        integration: { id: workspaceIntegration.id, name: workspaceIntegration.name, jwtClientId: integrationCredentials.client_id }
+        integration: { id: workspaceIntegration.id, name: workspaceIntegration.name, clientId: integrationCredentials.client_id }
       }
     }
 
@@ -97,7 +97,7 @@ class BaseCommand extends Command {
       integration = {
         id: workspaceIntegration.id,
         name: workspaceIntegration.name,
-        jwtClientId: workspaceIntegration[integrationType].client_id
+        clientId: workspaceIntegration[integrationType].client_id
       }
 
       // cache the integration details for future use

--- a/src/commands/event/registration/create.js
+++ b/src/commands/event/registration/create.js
@@ -26,7 +26,7 @@ class CreateCommand extends BaseCommand {
       const body = this.parseJSONFile(args.bodyJSONFile)
 
       if (!body.client_id) {
-        body.client_id = this.conf.integration.jwtClientId
+        body.client_id = this.conf.integration.clientId
       }
       // other checks are performed by the server
 

--- a/test/BaseCommand.test.js
+++ b/test/BaseCommand.test.js
@@ -41,6 +41,7 @@ const CONSOLE_CONFIG_KEY = 'console'
 const EVENT_CONFIG_KEY = 'events'
 const CONSOLE_API_KEY = 'aio-cli-console-auth'
 const IMS_CLI_CONFIG_KEY = 'ims'
+const TEST_WORKSPACE_NAME = 'Rug'
 
 let command
 beforeEach(() => {
@@ -82,7 +83,7 @@ describe('initSDK', () => {
       org: { code: 'A1B23456789DUDE@MoviesOrg', id: '09876', name: 'Coen Brothers' },
       integration: { id: '11111', clientId: '222333444555666', name: 'Project_WhiteRussian' },
       project: { id: '123456789', name: 'TheBigLebowski', title: "the dude's project" },
-      workspace: { id: '543216789', name: 'Rug' }
+      workspace: { id: '543216789', name: TEST_WORKSPACE_NAME }
     }
     consoleConfig = { org: _validConfig.org, project: { ..._validConfig.project, org_id: _validConfig.org.id }, workspace: _validConfig.workspace }
     eventsConfig = { integration: _validConfig.integration, workspaceId: _validConfig.workspace.id }
@@ -95,7 +96,7 @@ describe('initSDK', () => {
         workspace: {
           id: _validConfig.workspace.id,
           name: _validConfig.workspace.name,
-          title: 'Don\'t pee on the Rug',
+          title: `Don't pee on the ${TEST_WORKSPACE_NAME}`,
           details: {
             credentials: [
               { id: 'bad', name: 'not service', integration_type: 'oauth' },
@@ -203,11 +204,12 @@ describe('initSDK', () => {
       if (key === CONSOLE_CONFIG_KEY) return consoleConfig
       if (key === EVENT_CONFIG_KEY) return undefined
     })
+    const BAD_WORKSPACE_NAME = 'badDude'
     mockConsoleInstance.downloadWorkspaceJson.mockResolvedValue({
       body: {
         project: {
           workspace: {
-            name: 'badDude',
+            name: BAD_WORKSPACE_NAME,
             details: {
               credentials: [
                 { id: 'bad', name: 'not service', integration_type: 'oauth' }
@@ -217,7 +219,7 @@ describe('initSDK', () => {
         }
       }
     })
-    await expect(command.initSdk()).rejects.toThrow(command.getErrorMessageForInvalidCredentials('badDude'))
+    await expect(command.initSdk()).rejects.toThrow(command.getErrorMessageForInvalidCredentials(BAD_WORKSPACE_NAME))
   })
 
   test('not local config, console config is not set', async () => {
@@ -286,7 +288,7 @@ describe('initSDK', () => {
       if (type === 'local' && key === 'project') return localConfig.project
       if (type === 'env' && key === `${IMS_CLI_CONFIG_KEY}.contexts.${_validConfig.integration.name}`) return Object.values(localEnvConfig[IMS_CLI_CONFIG_KEY])[0]
     })
-    await expect(command.initSdk()).rejects.toThrow(command.getErrorMessageForInvalidCredentials('Rug'))
+    await expect(command.initSdk()).rejects.toThrow(command.getErrorMessageForInvalidCredentials(TEST_WORKSPACE_NAME))
   })
 
   test('local app config, missing .env credentials jwt client id', async () => {

--- a/test/BaseCommand.test.js
+++ b/test/BaseCommand.test.js
@@ -217,7 +217,7 @@ describe('initSDK', () => {
         }
       }
     })
-    await expect(command.initSdk()).rejects.toThrow('Workspace badDude has no JWT integration')
+    await expect(command.initSdk()).rejects.toThrow(command.getErrorMessageForInvalidCredentials('badDude'))
   })
 
   test('not local config, console config is not set', async () => {
@@ -286,7 +286,7 @@ describe('initSDK', () => {
       if (type === 'local' && key === 'project') return localConfig.project
       if (type === 'env' && key === `${IMS_CLI_CONFIG_KEY}.contexts.${_validConfig.integration.name}`) return Object.values(localEnvConfig[IMS_CLI_CONFIG_KEY])[0]
     })
-    await expect(command.initSdk()).rejects.toThrow('Workspace Rug has no JWT integration')
+    await expect(command.initSdk()).rejects.toThrow(command.getErrorMessageForInvalidCredentials('Rug'))
   })
 
   test('local app config, missing .env credentials jwt client id', async () => {

--- a/test/BaseCommand.test.js
+++ b/test/BaseCommand.test.js
@@ -80,7 +80,7 @@ describe('initSDK', () => {
   beforeEach(() => {
     _validConfig = {
       org: { code: 'A1B23456789DUDE@MoviesOrg', id: '09876', name: 'Coen Brothers' },
-      integration: { id: '11111', jwtClientId: '222333444555666', name: 'Project_WhiteRussian' },
+      integration: { id: '11111', clientId: '222333444555666', name: 'Project_WhiteRussian' },
       project: { id: '123456789', name: 'TheBigLebowski', title: "the dude's project" },
       workspace: { id: '543216789', name: 'Rug' }
     }
@@ -105,7 +105,7 @@ describe('initSDK', () => {
         }
       }
     }
-    localEnvConfig = { [IMS_CLI_CONFIG_KEY]: { contexts: { [_validConfig.integration.name.toLowerCase()]: { client_id: _validConfig.integration.jwtClientId } } } }
+    localEnvConfig = { [IMS_CLI_CONFIG_KEY]: { contexts: { [_validConfig.integration.name.toLowerCase()]: { client_id: _validConfig.integration.clientId } } } }
   })
   test('not local config, console and events config are set', async () => {
     aioConfig.get.mockImplementation((key, type) => {
@@ -117,7 +117,7 @@ describe('initSDK', () => {
     expect(command.consoleClient).toBe(mockConsoleInstance)
     expect(Console.init).toHaveBeenCalledWith('bowling', CONSOLE_API_KEY)
     expect(command.eventClient).toBe(mockEventsInstance)
-    expect(Events.init).toHaveBeenCalledWith(_validConfig.org.code, _validConfig.integration.jwtClientId, 'bowling')
+    expect(Events.init).toHaveBeenCalledWith(_validConfig.org.code, _validConfig.integration.clientId, 'bowling')
     expect(command.accessToken).toBe('bowling')
     expect(command.conf).toEqual({ ..._validConfig, isLocal: false })
     expect(mockConsoleInstance.downloadWorkspaceJson).toHaveBeenCalledTimes(0)
@@ -139,7 +139,7 @@ describe('initSDK', () => {
                   id: _validConfig.integration.id,
                   name: _validConfig.integration.name,
                   integration_type: 'service',
-                  jwt: { client_id: _validConfig.integration.jwtClientId }
+                  service: { client_id: _validConfig.integration.clientId }
                 }
               ]
             }
@@ -151,7 +151,7 @@ describe('initSDK', () => {
     expect(command.consoleClient).toBe(mockConsoleInstance)
     expect(Console.init).toHaveBeenCalledWith('bowling', CONSOLE_API_KEY)
     expect(command.eventClient).toBe(mockEventsInstance)
-    expect(Events.init).toHaveBeenCalledWith(_validConfig.org.code, _validConfig.integration.jwtClientId, 'bowling')
+    expect(Events.init).toHaveBeenCalledWith(_validConfig.org.code, _validConfig.integration.clientId, 'bowling')
     expect(command.accessToken).toBe('bowling')
     expect(command.conf).toEqual({ ..._validConfig, isLocal: false })
     expect(mockConsoleInstance.downloadWorkspaceJson).toHaveBeenCalledWith(_validConfig.org.id, _validConfig.project.id, _validConfig.workspace.id)
@@ -175,7 +175,7 @@ describe('initSDK', () => {
                   id: _validConfig.integration.id,
                   name: _validConfig.integration.name,
                   integration_type: 'service',
-                  jwt: { client_id: _validConfig.integration.jwtClientId }
+                  service: { client_id: _validConfig.integration.clientId }
                 }
               ]
             }
@@ -185,13 +185,13 @@ describe('initSDK', () => {
     })
     await command.initSdk()
     expect(aioConfig.set).toHaveBeenCalledWith(EVENT_CONFIG_KEY, {
-      integration: { id: _validConfig.integration.id, name: _validConfig.integration.name, jwtClientId: _validConfig.integration.jwtClientId },
+      integration: { id: _validConfig.integration.id, name: _validConfig.integration.name, clientId: _validConfig.integration.clientId },
       workspaceId: _validConfig.workspace.id
     }, false)
     expect(command.consoleClient).toBe(mockConsoleInstance)
     expect(Console.init).toHaveBeenCalledWith('bowling', CONSOLE_API_KEY)
     expect(command.eventClient).toBe(mockEventsInstance)
-    expect(Events.init).toHaveBeenCalledWith(_validConfig.org.code, _validConfig.integration.jwtClientId, 'bowling')
+    expect(Events.init).toHaveBeenCalledWith(_validConfig.org.code, _validConfig.integration.clientId, 'bowling')
     expect(command.accessToken).toBe('bowling')
     expect(command.conf).toEqual({ ..._validConfig, isLocal: false })
     expect(mockConsoleInstance.downloadWorkspaceJson).toHaveBeenCalledWith(_validConfig.org.id, _validConfig.project.id, _validConfig.workspace.id)
@@ -274,7 +274,7 @@ describe('initSDK', () => {
     expect(command.consoleClient).toBe(mockConsoleInstance)
     expect(Console.init).toHaveBeenCalledWith('bowling', CONSOLE_API_KEY)
     expect(command.eventClient).toBe(mockEventsInstance)
-    expect(Events.init).toHaveBeenCalledWith(_validConfig.org.code, _validConfig.integration.jwtClientId, 'bowling')
+    expect(Events.init).toHaveBeenCalledWith(_validConfig.org.code, _validConfig.integration.clientId, 'bowling')
     expect(command.accessToken).toBe('bowling')
     expect(command.conf).toEqual({ ..._validConfig, isLocal: true })
     expect(Ims.context.get).toHaveBeenCalledWith(_validConfig.integration.name)

--- a/test/commands/event/registration/create.test.js
+++ b/test/commands/event/registration/create.test.js
@@ -54,7 +54,7 @@ describe('console:registration:create', () => {
       org: { id: 'ORGID' },
       project: { id: 'PROJECTID' },
       workspace: { id: 'WORKSPACEID' },
-      integration: { id: 'INTEGRATIONID', jwtClientId: 'CLIENTID' }
+      integration: { id: 'INTEGRATIONID', clientId: 'CLIENTID' }
     }
   })
 

--- a/test/commands/event/registration/delete.test.js
+++ b/test/commands/event/registration/delete.test.js
@@ -44,7 +44,7 @@ describe('console:registration:delete', () => {
       org: { id: 'ORGID' },
       project: { id: 'PROJECTID' },
       workspace: { id: 'WORKSPACEID' },
-      integration: { id: 'INTEGRATIONID', jwtClientId: 'CLIENTID' }
+      integration: { id: 'INTEGRATIONID', clientId: 'CLIENTID' }
     }
     command.initSdk = jest.fn()
   })

--- a/test/commands/event/registration/get.test.js
+++ b/test/commands/event/registration/get.test.js
@@ -48,7 +48,7 @@ describe('console:registration:get', () => {
       org: { id: 'ORGID' },
       project: { id: 'PROJECTID' },
       workspace: { id: 'WORKSPACEID' },
-      integration: { id: 'INTEGRATIONID', jwtClientId: 'CLIENTID' }
+      integration: { id: 'INTEGRATIONID', clientId: 'CLIENTID' }
     }
     command.initSdk = jest.fn()
   })

--- a/test/commands/event/registration/list.test.js
+++ b/test/commands/event/registration/list.test.js
@@ -47,7 +47,7 @@ describe('console:registration:list', () => {
       org: { id: 'ORGID' },
       project: { id: 'PROJECTID' },
       workspace: { id: 'WORKSPACEID' },
-      integration: { id: 'INTEGRATIONID', jwtClientId: 'CLIENTID' }
+      integration: { id: 'INTEGRATIONID', clientId: 'CLIENTID' }
     }
     command.initSdk = jest.fn()
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds support for the newly added oAuth server-to-server credential. The fix was simple as done via https://github.com/adobe/aio-cli-plugin-events/commit/5861808e0a214c57ce9adda2505dbb6f10987e9f but the other changes are about removing the jwt references with generic references, and optimizing the unit tests for reusability.

**Note for reviewer:**
Reviewing commit-by-commit would be easier

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
This adds support for the new oAuth server-to-server credential in the events cli plugin.

## How Has This Been Tested?

By running the events plugin locally.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
