### PR TITLE
feat: support oauth s2s migration credential type

### DIFF
--- a/src/BaseCommand.js
+++ b/src/BaseCommand.js
@@ -26,6 +26,7 @@ const CONSOLE_API_KEY = 'aio-cli-console-auth'
 const EVENTS_CONFIG_KEY = 'events'
 const JWT_INTEGRATION_TYPE = 'service'
 const OAUTH_SERVER_TO_SERVER_INTEGRATION_TYPE = 'oauth_server_to_server'
+const OAUTH_SERVER_TO_SERVER_MIGRATE_INTEGRATION_TYPE = 'oauth_server_to_server_migrate'
 
 class BaseCommand extends Command {
   async initSdk () {
@@ -128,6 +129,7 @@ class BaseCommand extends Command {
     const workspaceIntegration = workspaceConfig.details.credentials &&
         workspaceConfig.details.credentials.find(c => {
           return c.integration_type === OAUTH_SERVER_TO_SERVER_INTEGRATION_TYPE ||
+                 c.integration_type === OAUTH_SERVER_TO_SERVER_MIGRATE_INTEGRATION_TYPE ||
                  c.integration_type === JWT_INTEGRATION_TYPE
         })
     if (!workspaceIntegration) {


### PR DESCRIPTION
Add support for `oauth_server_to_server_migrate` credential type

## Description

If I am in a workspace that is undergoing credential migration (jwt -> oauth), my workspace will only have one credential of type `oauth_server_to_server_migrate`: 

```
    "workspace": {
      "id": "4566206088344988936",
      "name": "Stage",
      "action_url": "https://53444-mgtestmigration1-stage.adobeioruntime.net",
      "app_url": "https://53444-mgtestmigration1-stage.adobeio-static.net",
      "details": {
        "credentials": [
          {
            "id": "455006",
            "name": "mgtestmigration1_J_1686769758519",
            "integration_type": "oauth_server_to_server_migrate"      <------
          }
        ],
        "services": [
          {
            "code": "AdobeIOManagementAPISDK",
            "name": "I/O Management API"
          },
          {
            "code": "CIS SDK",
            "name": "Adobe Photoshop API"
          }
        ],
        "events": {
          "registrations": [
           
          ]
        }
      }
    }
```


## Related Issue

## Motivation and Context

## How Has This Been Tested?

- `npm run test`
- locally linked plugin, only tested `aio event provider list`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x]  I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
