### PR TITLE
Fix difference between integration types and corresponding json keys

### DIFF
--- a/test/BaseCommand.test.js
+++ b/test/BaseCommand.test.js
@@ -140,7 +140,7 @@ describe('initSDK', () => {
                   id: _validConfig.integration.id,
                   name: _validConfig.integration.name,
                   integration_type: 'service',
-                  service: { client_id: _validConfig.integration.clientId }
+                  jwt: { client_id: _validConfig.integration.clientId }
                 }
               ]
             }
@@ -176,7 +176,7 @@ describe('initSDK', () => {
                   id: _validConfig.integration.id,
                   name: _validConfig.integration.name,
                   integration_type: 'service',
-                  service: { client_id: _validConfig.integration.clientId }
+                  jwt: { client_id: _validConfig.integration.clientId }
                 }
               ]
             }


### PR DESCRIPTION
## Description
This PR fixes the difference between integration types and corresponding json keys in Console's project config:
- For integration_type: `service`, console stores the credential config corresponding to `jwt` key
- For integration_type: `oauth_server_to_server`, console stores the credential config corresponding to `oauth_server_to_server` key
- For integration_type: `oauth_server_to_server_migrate`, console has both `jwt` and `oauth_server_to_server` credentials but we fetch details from `oauth_server_to_server` key

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

1. `npm run test`
2. Linked to local events plugin and tested `aio event provider list` command for all 3 types of project:
    1. Project with only JWT credential
    2. Project with only OAuth Server-to-Server credential
    3. A project that is undergoing migrating and has both JWT and OAuth S2S credential.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
