### PR TITLE
Add filtering options to fetch provider list for org

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,14 +326,19 @@ Get list of all Providers for the Organization
 
 ```
 USAGE
-  $ aio event provider list [--help] [-v] [--version] [-j | -y]
+  $ aio event provider list [--help] [-v] [--version] [--fetchEventMetadata] [--providerMetadataId <value> | -p <value>] [--instanceId <value>] [-j | -y]
 
 FLAGS
-  -j, --json     Output json
-  -v, --verbose  Verbose output
-  -y, --yml      Output yml
-  --help         Show help
-  --version      Show version
+  -j, --json                            Output json
+  -p, --providerMetadataIds=<value>...  Filter providers for org by list of provider metadata ids
+  -v, --verbose                         Verbose output
+  -y, --yml                             Output yml
+  --fetchEventMetadata                  Fetch event metadata with provider
+  --help                                Show help
+  --instanceId=<value>                  Filter providers for org by provider metadata id (and instance id if applicable)
+  --providerMetadataId=<value>          Filter providers for org by provider metadata id (and instance id if applicable)
+  --version                             Show version
+
 
 DESCRIPTION
   Get list of all Providers for the Organization

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@adobe/aio-lib-console": "^4.0.0",
     "@adobe/aio-lib-core-config": "^3.0.0",
     "@adobe/aio-lib-core-logging": "^2.0.0",
-    "@adobe/aio-lib-events": "^3.0.0",
+    "@adobe/aio-lib-events": "^3.1.0",
     "@adobe/aio-lib-ims": "^6.0.1",
     "@oclif/core": "^1.5.2",
     "js-yaml": "^3.13.1",

--- a/src/commands/event/provider/list.js
+++ b/src/commands/event/provider/list.js
@@ -20,7 +20,15 @@ class ProviderListCommand extends BaseCommand {
     try {
       await this.initSdk()
       cli.action.start('Fetching all Event Providers')
-      const providers = await this.eventClient.getAllProviders(this.conf.org.id)
+      const options = {
+        fetchEventMetadata: flags.fetchEventMetadata,
+        filterBy: {
+          providerMetadataId: flags.providerMetadataId,
+          instanceId: flags.instanceId,
+          providerMetadataIds: flags.providerMetadataIds
+        }
+      }
+      const providers = await this.eventClient.getAllProviders(this.conf.org.id, options)
       cli.action.stop()
       if (flags.json) {
         this.printJson(providers)
@@ -65,6 +73,25 @@ ProviderListCommand.aliases = [
 
 ProviderListCommand.flags = {
   ...BaseCommand.flags,
+  fetchEventMetadata: Flags.boolean({
+    description: 'Fetch event metadata with provider'
+  }),
+  providerMetadataId: Flags.string({
+    multiple: false,
+    description: 'Filter providers for org by provider metadata id (and instance id if applicable)',
+    exclusive: ['providerMetadataIds']
+  }),
+  instanceId: Flags.string({
+    multiple: false,
+    description: 'Filter providers for org by provider metadata id (and instance id if applicable)',
+    exclusive: ['providerMetadataIds']
+  }),
+  providerMetadataIds: Flags.string({
+    multiple: true,
+    char: 'p',
+    description: 'Filter providers for org by list of provider metadata ids',
+    exclusive: ['providerMetadataId', 'instanceId']
+  }),
   json: Flags.boolean({
     description: 'Output json',
     char: 'j',

--- a/src/commands/event/provider/list.js
+++ b/src/commands/event/provider/list.js
@@ -83,14 +83,13 @@ ProviderListCommand.flags = {
   }),
   instanceId: Flags.string({
     multiple: false,
-    description: 'Filter providers for org by provider metadata id (and instance id if applicable)',
-    exclusive: ['providerMetadataIds']
+    description: 'Filter providers for org by provider metadata id (and instance id if applicable)'
   }),
   providerMetadataIds: Flags.string({
     multiple: true,
     char: 'p',
     description: 'Filter providers for org by list of provider metadata ids',
-    exclusive: ['providerMetadataId', 'instanceId']
+    exclusive: ['providerMetadataId']
   }),
   json: Flags.boolean({
     description: 'Output json',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update aio-lib-events version
Add options to filter provider by filtering options such as provider metadata id and instance id or fetch all providers for a list of provider metadata ids. 
Option to fetch event metadata associated with the providers ( useful when the fetch is made using json or yaml format )

## Related Issue

https://github.com/adobe/aio-lib-events/pull/36

## Motivation and Context

Helper options to fetch specific providers for org

## How Has This Been Tested?

Unit tests
Executing commands locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
