### PR TITLE
Force sync registrations on --force-events flag 

### DIFF
--- a/src/hooks/post-deploy-event-reg.js
+++ b/src/hooks/post-deploy-event-reg.js
@@ -12,6 +12,6 @@ const {
   WEBHOOK, deployRegistration
 } = require('./utils/hook-utils')
 
-module.exports = async function ({ appConfig }) {
-  await deployRegistration({ appConfig }, WEBHOOK, 'post-deploy-event-reg')
+module.exports = async function ({ appConfig, force }) {
+  await deployRegistration({ appConfig }, WEBHOOK, 'post-deploy-event-reg', force)
 }

--- a/src/hooks/pre-deploy-event-reg.js
+++ b/src/hooks/pre-deploy-event-reg.js
@@ -13,7 +13,7 @@ const {
   JOURNAL, getDeliveryType
 } = require('./utils/hook-utils')
 
-module.exports = async function ({ appConfig }) {
+module.exports = async function ({ appConfig, force }) {
   if (appConfig && appConfig.events) {
     const registrations = appConfig.events.registrations
     for (const registrationName in registrations) {

--- a/src/hooks/pre-deploy-event-reg.js
+++ b/src/hooks/pre-deploy-event-reg.js
@@ -13,7 +13,7 @@ const {
   JOURNAL, getDeliveryType
 } = require('./utils/hook-utils')
 
-module.exports = async function ({ appConfig, force }) {
+module.exports = async function ({ appConfig }) {
   if (appConfig && appConfig.events) {
     const registrations = appConfig.events.registrations
     for (const registrationName in registrations) {

--- a/src/hooks/utils/hook-utils.js
+++ b/src/hooks/utils/hook-utils.js
@@ -140,11 +140,9 @@ async function createOrUpdateRegistration (body, eventsSDK, existingRegistration
  * @param {object} project - project details from .aio config file
  */
 async function deleteRegistration (eventsSDK, existingRegistration, project) {
-  if (existingRegistration) {
-    await eventsSDK.eventsClient.deleteRegistration(eventsSDK.orgId, project.id, project.workspace.id,
-      existingRegistration.registration_id)
-    console.log('Deleted registration with name:' + existingRegistration.name + ' and id:' + existingRegistration.registration_id)
-  }
+  await eventsSDK.eventsClient.deleteRegistration(eventsSDK.orgId, project.id, project.workspace.id,
+    existingRegistration.registration_id)
+  console.log('Deleted registration with name:' + existingRegistration.name + ' and id:' + existingRegistration.registration_id)
 }
 
 /**
@@ -202,8 +200,7 @@ async function deployRegistration ({ appConfig: { events, project } }, expectedD
       try {
         let existingRegistration
         if (registrationsFromWorkspace && registrationsFromWorkspace[registrationName]) { existingRegistration = registrationsFromWorkspace[registrationName] }
-        await createOrUpdateRegistration(body, eventsSDK,
-          existingRegistration, project)
+        await createOrUpdateRegistration(body, eventsSDK, existingRegistration, project)
       } catch (e) {
         throw new Error(
           e + '\ncode:' + e.code + '\nDetails:' + JSON.stringify(
@@ -217,10 +214,7 @@ async function deployRegistration ({ appConfig: { events, project } }, expectedD
     console.log('The following registrations will be deleted: ', registrationsToDeleted)
     for (const registrationName of registrationsToDeleted) {
       try {
-        if (registrationsFromWorkspace && registrationsFromWorkspace[registrationName]) {
-          await deleteRegistration(eventsSDK,
-            registrationsFromWorkspace[registrationName], project)
-        }
+        await deleteRegistration(eventsSDK, registrationsFromWorkspace[registrationName], project)
       } catch (e) {
         throw new Error(
           e + '\ncode:' + e.code + '\nDetails:' + JSON.stringify(

--- a/test/__fixtures__/registration/list.json
+++ b/test/__fixtures__/registration/list.json
@@ -14,7 +14,7 @@
                     }
                 },
                 "id": 11111,
-                "name": "bowling 1",
+                "name": "Event Registration 1",
                 "description": "let me know when we can go play bowling!",
                 "client_id": "1234654902189324798",
                 "webhook_url": "https://send-me-a-bowling-event.com/right-now",
@@ -48,7 +48,7 @@
                     }
                 },
                 "id": 22222,
-                "name": "table tenis 2",
+                "name": "Event Registration 2",
                 "description": "registration for table tennis events",
                 "client_id": "1234654902189324798",
                 "webhook_url": "https://send-me-a-table-tennis-event.com/please",

--- a/test/__fixtures__/registration/list.txt
+++ b/test/__fixtures__/registration/list.txt
@@ -1,4 +1,4 @@
  ID                                    NAME                     ENABLED   DELIVERY_TYPE WEBHOOK_STATUS 
  ───────────────────────────────────── ──────────────────────── ───────── ───────────── ────────────── 
- REGID1                                bowling 1                true      webhook       verified       
- REGID2                                table tenis 2            true      webhook       verified       
+ REGID1                                Event Registration 1     true      webhook       verified       
+ REGID2                                Event Registration 2     true      webhook       verified       

--- a/test/__fixtures__/registration/list.yml
+++ b/test/__fixtures__/registration/list.yml
@@ -11,7 +11,7 @@ _embedded:
           href: >-
             https://api.adobe.io/events/consumerOrgId/projectId/workspaceId/registrations/REGID1
       id: 11111
-      name: bowling 1
+      name: Event Registration 1
       description: let me know when we can go play bowling!
       client_id: '1234654902189324798'
       webhook_url: 'https://send-me-a-bowling-event.com/right-now'
@@ -39,7 +39,7 @@ _embedded:
           href: >-
             https://api.adobe.io/events/consumerOrgId/projectId/workspaceId/registrations/REGID2
       id: 22222
-      name: table tenis 2
+      name: Event Registration 2
       description: registration for table tennis events
       client_id: '1234654902189324798'
       webhook_url: 'https://send-me-a-table-tennis-event.com/please'

--- a/test/hooks/post-deploy-event-reg.test.js
+++ b/test/hooks/post-deploy-event-reg.test.js
@@ -14,7 +14,8 @@ jest.mock('@adobe/aio-lib-events')
 const eventsSdk = require('@adobe/aio-lib-events')
 const mockEventsSdkInstance = {
   createRegistration: jest.fn(),
-  updateRegistration: jest.fn()
+  updateRegistration: jest.fn(),
+  getAllRegistrationsForWorkspace: jest.fn()
 }
 jest.mock('@adobe/aio-lib-ims')
 const { getToken } = require('@adobe/aio-lib-ims')
@@ -126,6 +127,7 @@ describe('post deploy event registration hook interfaces', () => {
     getToken.mockReturnValue('accessToken')
     const events = mock.data.sampleEvents
     events.registrations['Event Registration 1'].delivery_type = 'webhook'
+    mockEventsSdkInstance.getAllRegistrationsForWorkspace.mockResolvedValue(mock.data.getAllWebhookRegistrationsWithEmptyResponse)
     mockEventsSdkInstance.createRegistration.mockReturnValue(mock.data.createWebhookRegistrationResponse)
     const projectWithEmptyEvents = mock.data.sampleProjectWithoutEvents
     projectWithEmptyEvents.workspace.details.events = {}
@@ -141,6 +143,7 @@ describe('post deploy event registration hook interfaces', () => {
     expect(typeof hook).toBe('function')
     process.env = mock.data.dotEnv
     getToken.mockReturnValue('accessToken')
+    mockEventsSdkInstance.getAllRegistrationsForWorkspace.mockResolvedValue(mock.data.getAllWebhookRegistrationsResponse)
     mockEventsSdkInstance.updateRegistration.mockRejectedValueOnce(JSON.stringify({
       code: 500,
       errorDetails: {
@@ -149,7 +152,7 @@ describe('post deploy event registration hook interfaces', () => {
     }))
     await expect(hook({ appConfig: { project: mock.data.sampleProject, events: mock.data.sampleEvents } })).rejects.toThrowError()
     expect(mockEventsSdkInstance.updateRegistration).toBeCalledTimes(1)
-    expect(mockEventsSdkInstance.updateRegistration).toHaveBeenCalledWith(CONSUMER_ID, PROJECT_ID, WORKSPACE_ID, 'registrationId1',
+    expect(mockEventsSdkInstance.updateRegistration).toHaveBeenCalledWith(CONSUMER_ID, PROJECT_ID, WORKSPACE_ID, 'REGID1',
       mock.data.hookDecodedEventRegistration1
     )
   })
@@ -159,10 +162,11 @@ describe('post deploy event registration hook interfaces', () => {
     expect(typeof hook).toBe('function')
     process.env = mock.data.dotEnv
     getToken.mockReturnValue('accessToken')
+    mockEventsSdkInstance.getAllRegistrationsForWorkspace.mockResolvedValue(mock.data.getAllWebhookRegistrationsResponse)
     mockEventsSdkInstance.updateRegistration.mockReturnValue(mock.data.createWebhookRegistrationResponse)
     await expect(hook({ appConfig: { project: mock.data.sampleProject, events: mock.data.sampleEvents } })).resolves.not.toThrowError()
     expect(mockEventsSdkInstance.updateRegistration).toBeCalledTimes(1)
-    expect(mockEventsSdkInstance.updateRegistration).toHaveBeenCalledWith(CONSUMER_ID, PROJECT_ID, WORKSPACE_ID, 'registrationId1',
+    expect(mockEventsSdkInstance.updateRegistration).toHaveBeenCalledWith(CONSUMER_ID, PROJECT_ID, WORKSPACE_ID, 'REGID1',
       mock.data.hookDecodedEventRegistration1
     )
   })

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -603,6 +603,7 @@ const hookDecodedEventRegistration1 = {
   client_id: 'serviceApiKey',
   description: 'Registration for IO Events 1',
   delivery_type: 'webhook',
+  runtime_action: 'poc-event-1',
   events_of_interest: [{
     provider_id: 'providerId1',
     event_code: 'eventCode1'

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -272,6 +272,12 @@ const createWebhookRegistrationResponse = {
   ...getWebhookRegistrationResponse
 }
 
+const getAllWebhookRegistrationsWithEmptyResponse = {
+  _embedded: {
+    registrations: []
+  }
+}
+
 const getAllWebhookRegistrationsResponse = {
   _embedded: {
     registrations: [
@@ -288,7 +294,7 @@ const getAllWebhookRegistrationsResponse = {
           }
         },
         id: 11111,
-        name: 'bowling 1',
+        name: 'Event Registration 1',
         description: 'let me know when we can go play bowling!',
         client_id: '1234654902189324798',
         webhook_url: 'https://send-me-a-bowling-event.com/right-now',
@@ -322,7 +328,7 @@ const getAllWebhookRegistrationsResponse = {
           }
         },
         id: 22222,
-        name: 'table tenis 2',
+        name: 'Event Registration 2',
         description: 'registration for table tennis events',
         client_id: '1234654902189324798',
         webhook_url: 'https://send-me-a-table-tennis-event.com/please',
@@ -660,6 +666,7 @@ const data = {
   getAllEventMetadata,
   createWebhookRegistrationResponse,
   getAllWebhookRegistrationsResponse,
+  getAllWebhookRegistrationsWithEmptyResponse,
   getWebhookRegistrationResponse,
   createWebhookRegistrationInputJSON,
   createWebhookRegistrationInputJSONNoClientId,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The PR contains the following changes:

Since `aio app use` is a pre-requisite for deploying registrations and may not always be executed by the user, this PR removes this dependency by making a call to IO events to always fetch the registrations in the workspace before updating them. 

--force-events flag if true, will result in deletion of registrations that are part of the app.config.yaml file but not part of the Console workspace. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
