### PR TITLE
Throw error if provider metadata does not have provider id mapping

### DIFF
--- a/src/hooks/utils/hook-utils.js
+++ b/src/hooks/utils/hook-utils.js
@@ -47,6 +47,10 @@ function getEventsOfInterestForRegistration (registration,
   const eventsOfInterestCompressed = registration.events_of_interest
   eventsOfInterestCompressed.forEach(eventOfInterest => {
     const providerId = providerMetadataToProviderIdMapping[eventOfInterest.provider_metadata]
+    if (!providerId) {
+      throw new Error(
+            `No provider id mapping found for provider metadata ${eventOfInterest.provider_metadata}. Skipping event registration`)
+    }
     const eventCodesList = eventOfInterest.event_codes
     for (const eventCode of eventCodesList) {
       eventsOfInterest.push({

--- a/test/hooks/post-deploy-event-reg.test.js
+++ b/test/hooks/post-deploy-event-reg.test.js
@@ -92,6 +92,19 @@ describe('post deploy event registration hook interfaces', () => {
     await expect(hook({ appConfig: { project: mock.data.sampleProject, events: mock.data.sampleEvents } })).rejects.toThrow(new Error('No environment variables for provider metadata to provider id mappings found.'))
   })
 
+  test('providerMetadata to providerId missing for some providers', async () => {
+    const hook = require('../../src/hooks/post-deploy-event-reg')
+    expect(typeof hook).toBe('function')
+    process.env = mock.data.dotEnvMissingProviderMetadataToProviderIdMapping
+    process.env.AIO_events_providermetadata_to_provider_mapping = ''
+    process.env = {
+      ...mock.data.dotEnvMissingProviderMetadataToProviderIdMapping,
+      AIO_EVENTS_PROVIDERMETADATA_TO_PROVIDER_MAPPING: 'providerMetadata2:providerId2'
+    }
+    getToken.mockReturnValue('accessToken')
+    await expect(hook({ appConfig: { project: mock.data.sampleProject, events: mock.data.sampleEvents } })).rejects.toThrow(new Error('No provider id mapping found for provider metadata providerMetadata1. Skipping event registration'))
+  })
+
   test('error in create registration', async () => {
     const hook = require('../../src/hooks/post-deploy-event-reg')
     expect(typeof hook).toBe('function')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Event registration should be skipped if the provider metadata does not have the provider id mapping. This is to fail early. Otherwise the call to create/update registration will fail. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
