### PR TITLE
Not fatal

### DIFF
--- a/src/hooks/utils/hook-utils.js
+++ b/src/hooks/utils/hook-utils.js
@@ -174,12 +174,11 @@ async function getAllRegistrationsForWorkspace (eventsSDK, project) {
  */
 async function deployRegistration ({ appConfig: { events, project } }, expectedDeliveryType, hookType, forceEventsFlag) {
   if (!project) {
-    throw new Error(
-            `No project found, skipping event registration in ${hookType} hook`)
+    aioLogger.debug(`No project found, skipping event registration in ${hookType} hook`)
+    return
   }
   if (!events) {
-    aioLogger.debug(
-      `No events to register, skipping event registration in ${hookType} hook`)
+    aioLogger.debug(`No events to register, skipping event registration in ${hookType} hook`)
     return
   }
   const eventsSDK = await initEventsSdk(project)

--- a/src/hooks/utils/hook-utils.js
+++ b/src/hooks/utils/hook-utils.js
@@ -236,8 +236,8 @@ async function deployRegistration ({ appConfig: { events, project } }, expectedD
  */
 async function undeployRegistration ({ appConfig: { events, project } }) {
   if (!project) {
-    throw new Error(
-      'No project found, skipping deletion of event registrations')
+    aioLogger.debug('No project with events to delete, skipping deletion of event registrations')
+    return
   }
   if (!events) {
     aioLogger.debug('No events to delete, skipping deletion of event registrations')

--- a/test/hooks/post-deploy-event-reg.test.js
+++ b/test/hooks/post-deploy-event-reg.test.js
@@ -41,16 +41,10 @@ describe('post deploy event registration hook interfaces', () => {
     expect(typeof hook).toBe('function')
   })
 
-  test('command-error', async () => {
+  test('no project should return without error', async () => {
     const hook = require('../../src/hooks/post-deploy-event-reg')
     expect(typeof hook).toBe('function')
-    await expect(hook({ appConfig: {} })).rejects.toThrow(new Error('No project found, skipping event registration in post-deploy-event-reg hook'))
-  })
-
-  test('no project error', async () => {
-    const hook = require('../../src/hooks/post-deploy-event-reg')
-    expect(typeof hook).toBe('function')
-    await expect(hook({ appConfig: {} })).rejects.toThrow(new Error('No project found, skipping event registration in post-deploy-event-reg hook'))
+    await expect(hook({ appConfig: {} })).resolves.not.toThrow()
   })
 
   test('no events should return without error', async () => {

--- a/test/hooks/pre-undeploy-event-reg.test.js
+++ b/test/hooks/pre-undeploy-event-reg.test.js
@@ -39,10 +39,10 @@ describe('pre undeploy event registration hook interfaces', () => {
     expect(typeof hook).toBe('function')
   })
 
-  test('no project error', async () => {
+  test('no project should return without error', async () => {
     const hook = require('../../src/hooks/pre-undeploy-event-reg')
     expect(typeof hook).toBe('function')
-    await expect(hook({ appConfig: {} })).rejects.toThrow(new Error('No project found, skipping deletion of event registrations'))
+    await expect(hook({ appConfig: {} })).resolves.not.toThrow()
   })
 
   test('no events should return without error', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hooks should be very careful not to fire errors on missing input.  There are legacy projects that do not have the same config structure that should continue to work even if the events hook is installed.  This changes the behavior to simply log if the hook is called without a project.

## Related Issue

ACNA-2599
[adobe/aio-cli/issues/524](https://github.com/adobe/aio-cli/issues/524)



## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
